### PR TITLE
Fix name collision with ScratchLogin

### DIFF
--- a/src/SpecialRequestAccount.php
+++ b/src/SpecialRequestAccount.php
@@ -8,63 +8,63 @@ class SpecialRequestAccount extends SpecialPage {
 	function __construct() {
 		parent::__construct( 'RequestAccount' );
 	}
-	
+
 	function sanitizedPostData(&$request, &$session, &$out_error) {
 		$username = $request->getText('scratchusername');
-		
-		if ($username == '' || !isValidScratchUsername($username)) {
+
+		if ($username == '' || !ScratchVerification::isValidScratchUsername($username)) {
 			$out_error = 'invalid scratch username';
 			return;
 		}
-		
+
 		if (userExists($username)) {
 			$out_error = 'user already exists';
 			return;
 		}
-		
+
 		if (hasActiveRequest($username)) {
 			$out_error = 'user already has active request';
 			return;
 		}
-		
-		if (topVerifCommenter(sessionVerificationCode($session)) != $username) {
+
+		if (ScratchVerification::topVerifCommenter(ScratchVerification::sessionVerificationCode($session)) != $username) {
 			$out_error = 'verification code missing';
 			return;
 		}
-		
+
 		$blockReason = getBlockReason($username);
 		if ($blockReason) {
 			$out_error = 'username blocked with reason: ' . $blockReason; // note : blocks are not publicly visible on scratch, so this needs to run after checking the verification code
 			return;
 		}
-		
+
 		$email = $request->getText('email');
 		if ($email != '' && !Sanitizer::validateEmail($email)) {
 			$out_error = 'invalid email';
 			return;
 		}
-		
+
 		if($request->getText('agree') != "true"){
 			$out_error = "did not agree to checkbox";
 			return;
 		}
-		
+
 		$request_notes = $request->getText('requestnotes');
-		
+
 		if($request_notes == ""){
 			$out_error = "no request notes";
 			return;
 		}
-		
 
-		
+
+
 		return ['username' => $username, 'email' => $email, 'requestnotes' => $request_notes];
 	}
-	
+
 	function getGroupName() {
 		return 'login';
 	}
-	
+
 	function formSectionHeader($name) {
 		$form = Xml::openElement('fieldset');
 		$form .= Xml::openElement('legend');
@@ -73,88 +73,88 @@ class SpecialRequestAccount extends SpecialPage {
 
 		return $form;
 	}
-	
+
 	function formSectionFooter() {
 		return Xml::closeElement('fieldset');
 	}
-	
+
 	function usernameAndVerificationArea(&$session, $request) {
 		$form = $this->formSectionHeader(wfMessage('scratch-confirmaccount-usernameverification'));
-		
+
 		$form .= '<p>';
 		$form .= '<label for="scratch-confirmaccount-username">' . wfMessage('scratch-confirmaccount-scratchusername') . '</label><br />';
 		$form .= Html::rawElement('input', ['type' => 'text', 'name' => 'scratchusername', 'id' => 'scratch-confirmaccount-username', 'value' => $request->getText('scratchusername')]);
 		$form .= '</p>';
-		
+
 		$form .= '<p>';
 		$form .= '<label for="scratch-confirmaccount-email">' . wfMessage('scratch-confirmaccount-email') . '</label><br />';
 		$form .= Html::rawElement('input', ['type' => 'email', 'name' => 'email', 'id' => 'scratch-confirmaccount-email', 'value' => $request->getText('email')]);
 		$form .= '</p>';
-		
-		$form .= '<p>' . wfMessage('scratch-confirmaccount-vercode-explanation')->params(sprintf(PROJECT_LINK, wgScratchVerificationProjectID()))->parse() . '</p>';
-		$form .= '<p style=\"font-weight: bold\">' . sessionVerificationCode($session) . '</p>';
-		
+
+		$form .= '<p>' . wfMessage('scratch-confirmaccount-vercode-explanation')->params(sprintf(ScratchVerification::PROJECT_LINK, wgScratchVerificationProjectID()))->parse() . '</p>';
+		$form .= '<p style=\"font-weight: bold\">' . ScratchVerification::sessionVerificationCode($session) . '</p>';
+
 		$form .= $this->formSectionFooter();
-		
+
 		return $form;
 	}
-	
+
 	function requestNotesArea(&$request) {
 		$form = $this->formSectionHeader(wfMessage('scratch-confirmaccount-requestnotes'));
-		
+
 		$form .= '<p>' . wfMessage('scratch-confirmaccount-requestnotes-explanation')->parse() . '</p>';
-		
+
 		$form .= '<label for="scratch-confirmaccount-requestnotes">' . wfMessage('scratch-confirmaccount-requestnotes') . '</label>';
 		$form .= Html::element('textarea', ['id' => 'scratch-confirmaccount-requestnotes', 'name' => 'requestnotes'], $request->getText('requestnotes'));
-		
+
 		$form .= '<br>';
 
 		$form .= Html::element('input', ['type' => 'checkbox', 'name' => 'agree', 'value' => 'true']);
 
 		$form .= ' ' . wfMessage('scratch-confirmaccount-checkbox-agree') . '<br>';
-		
+
 		$form .= $this->formSectionFooter();
-		
+
 		return $form;
 	}
-	
+
 	function guidelinesArea() {
 		return '';
 	}
-	
+
 	function handleFormSubmission(&$request, &$output, &$session) {
 		//validate and sanitize the input
 		$formData = $this->sanitizedPostData($request, $session, $error);
 		if ($error != '') {
 			return $this->requestForm($request, $output, $session, $error);
 		}
-		
+
 		//now actually create the request and reset the verification code
 		createAccountRequest($formData['username'], $formData['requestnotes'], $formData['email'], $request->getIP());
-		generateNewCodeForSession($session);
-		
+		ScratchVerification::generateNewCodeForSession($session);
+
 		//and show the output
 		$output->addHTML('success');
 	}
-	
+
 	function requestForm(&$request, &$output, &$session, $error = '') {
 		$form = Xml::openElement('form', [ 'method' => 'post', 'name' => 'requestaccount', 'action' => $this->getPageTitle()->getLocalUrl(), 'enctype' => 'multipart/form-data' ]);
-		
+
 		//display errors if there are any relevant
 		//TODO: show this in an error box
 		if ($error != '') {
 			$form .= '<p>' . $error . '</p>';
 		}
-		
+
 		//form body
 		$form .= $this->usernameAndVerificationArea($session, $request);
 		$form .= $this->requestNotesArea($request);
 		$form .= $this->guidelinesArea();
-		
+
 		$form .= '<input type="submit" value="' . wfMessage('scratch-confirmaccount-request-submit') . '" />';
-		
+
 		$form .= Xml::closeElement('form');
-		
+
 		$output->addHTML($form);
 	}
 
@@ -163,7 +163,7 @@ class SpecialRequestAccount extends SpecialPage {
 		$output = $this->getOutput();
 		$session = $this->getRequest()->getSession();
 		$this->setHeaders();
-		
+
 		if ($request->wasPosted()) {
 			return $this->handleFormSubmission($request, $output, $session);
 		} else {

--- a/src/verification/ScratchVerification.php
+++ b/src/verification/ScratchVerification.php
@@ -1,52 +1,54 @@
 <?php
 require_once __DIR__ . '/../common.php';
 
-define('SCRATCH_COMMENT_API_URL', 'https://api.scratch.mit.edu/users/%s/projects/%s/comments?offset=0&limit=20');
-define('PROJECT_LINK', 'https://scratch.mit.edu/projects/%s/');
+class ScratchVerification {
+	const SCRATCH_COMMENT_API_URL = 'https://api.scratch.mit.edu/users/%s/projects/%s/comments?offset=0&limit=20';
+	const PROJECT_LINK = 'https://scratch.mit.edu/projects/%s/';
 
-function randomVerificationCode() {
-	// translate 0->A, 1->B, etc to bypass Scratch phone number censor
-	return strtr(hash('sha256', random_bytes(16)), '0123456789', 'ABCDEFGHIJ');
-}
-
-function generateNewCodeForSession(&$session) {
-	$session->persist();
-	$session->set('vercode', randomVerificationCode());
-	$session->save();
-}
-
-function sessionVerificationCode(&$session) {
-	if (!$session->exists('vercode')) {
-		generateNewCodeForSession($session);
+	private static function randomVerificationCode() {
+		// translate 0->A, 1->B, etc to bypass Scratch phone number censor
+		return strtr(hash('sha256', random_bytes(16)), '0123456789', 'ABCDEFGHIJ');
 	}
-	return $session->get('vercode');
-}
 
-function commentsForProject($author, $project_id) {
-	return json_decode(file_get_contents(sprintf(
-		SCRATCH_COMMENT_API_URL, $author, $project_id
-	)), true);
-}
-
-function verifComments() {
-	return commentsForProject(
-		wgScratchVerificationProjectAuthor(),
-		wgScratchVerificationProjectID()
-	);
-}
-
-function isValidScratchUsername($username) {
-	return !preg_match('/^_+|_+$|__+|[^a-zA-Z0-9\-_]/', $username);
-}
-
-function topVerifCommenter($req_comment) {
-	$comments = verifComments();
-
-	$matching_comments = array_filter($comments, function(&$comment) use($req_comment) {
-		return !preg_match('/^_+|_+$|__+/', $comment['author']['username']) && stristr($comment['content'], $req_comment);
-	});
-	if (empty($matching_comments)) {
-		return null;
+	public static function generateNewCodeForSession(&$session) {
+		$session->persist();
+		$session->set('vercode', self::randomVerificationCode());
+		$session->save();
 	}
-	return $matching_comments[0]['author']['username'];
+
+	public static function sessionVerificationCode(&$session) {
+		if (!$session->exists('vercode')) {
+			self::generateNewCodeForSession($session);
+		}
+		return $session->get('vercode');
+	}
+
+	private static function commentsForProject($author, $project_id) {
+		return json_decode(file_get_contents(sprintf(
+			self::SCRATCH_COMMENT_API_URL, $author, $project_id
+		)), true);
+	}
+
+	private static function verifComments() {
+		return self::commentsForProject(
+			wgScratchVerificationProjectAuthor(),
+			wgScratchVerificationProjectID()
+		);
+	}
+
+	public static function isValidScratchUsername($username) {
+		return !preg_match('/^_+|_+$|__+|[^a-zA-Z0-9\-_]/', $username);
+	}
+
+	public static function topVerifCommenter($req_comment) {
+		$comments = self::verifComments();
+
+		$matching_comments = array_filter($comments, function(&$comment) use($req_comment) {
+			return !preg_match('/^_+|_+$|__+/', $comment['author']['username']) && stristr($comment['content'], $req_comment);
+		});
+		if (empty($matching_comments)) {
+			return null;
+		}
+		return $matching_comments[0]['author']['username'];
+	}
 }


### PR DESCRIPTION
Previously name collision existed in ScratchVerification.php. This is fixed by moving all functions to class static methods.