### PR TITLE
Email support

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -52,6 +52,7 @@
 	"scratch-confirmaccount-request-options": "Request options",
 	"scratch-confirmaccount-search-label": "Search by username",
 	"scratch-confirmaccount-search": "Search",
+	"scratch-confirmaccount-account-created": "Account created.",
 
 	"scratch-confirmaccount-invalid-username": "The username is invalid. Make sure to type your Scratch username. Due to technical reasons, some usernames which start or end with underscore are not allowed. Please contact an administrator if this is the case for you",
 	"scratch-confirmaccount-user-exists": "The user is already registered.",
@@ -84,8 +85,18 @@
 	"scratch-confirmaccount-see-request": "See your request",
 	"scratch-confirmaccount-action-unauthorized": "You cannot perform this action.",
 	"scratch-confirmaccount-set-status-awaiting-admin-done": "Your comment has been sent. The administrators will handle it and send a response.",
+	"scratch-confirmaccount-invalid-email-token": "Could not confirm your email. Try re-sending your email at [$1 the request page].",
+	"scratch-confirmaccount-email-confirmed": "Your email has been confirmed",
+	"scratch-confirmaccount-success-email": "Account request has been received. We sent you an email to confirm the email address. The administrators will handle it and send a response.",
+	"scratch-confirmaccount-resend": "Resend Confirmation Email",
+	"scratch-confirmaccount-already-accepted-email": "Account request is already accepted; you must log in and change the email from the [[Special:Preferences|preferences]].",
+	"scratch-confirmaccount-email-unregistered": "There is no unconfirmed email address associated with this request.",
+	"scratch-confirmaccount-email-resent": "Confirmation email has been re-sent.",
 
 	"scratch-confirmaccount-requests-awaiting": "<b>$2</b> $1 $3 awaiting. <b>Your attention is needed!</b>",
 	"scratch-confirmaccount-requests-awaiting-linktext": "{{PLURAL:$1|request|requests}}",
-	"scratch-confirmaccount-requests-awaiting-isare": "{{PLURAL:$1|is|are}}"
+	"scratch-confirmaccount-requests-awaiting-isare": "{{PLURAL:$1|is|are}}",
+
+	"scratch-confirmaccount-email-subject": "Please confirm the email for $1",
+	"scratch-confirmaccount-email-body": "Hello $1,\n\nSomeone requested an account on $2. To confirm the email, please open this address in your browser:\n\n$3\n\nThis link will expire at $4. Note that you will be asked to enter your username and password during the process.\nConfirming your email address is optional, but it will allow you to reset your password via email. If you did not request the account on $2, please ignore this email."
 }

--- a/sql/requests.sql
+++ b/sql/requests.sql
@@ -11,7 +11,10 @@ CREATE TABLE IF NOT EXISTS /*_*/scratch_accountrequest_request (
 	request_expiry varbinary(14),
 	request_notes TEXT NOT NULL,
 	request_ip VARCHAR(255) NOT NULL,
-	request_status VARCHAR(255) binary NOT NULL DEFAULT 'new'
+	request_status VARCHAR(255) binary NOT NULL DEFAULT 'new',
+	request_email_token varbinary(32),
+	request_email_token_expiry varbinary(14),
+	request_email_confirmed TINYINT(1) NOT NULL DEFAULT 0
 )/*$wgDBTableOptions*/;
 
 

--- a/src/email.php
+++ b/src/email.php
@@ -1,0 +1,43 @@
+<?php
+
+require_once __DIR__ . '/database/DatabaseInteractions.php';
+
+function confirmationToken($request_id, &$expiration) {
+    global $wgUserEmailConfirmationTokenExpiry;
+    $now = time();
+    $expires = $now + $wgUserEmailConfirmationTokenExpiry;
+    $expiration = wfTimestamp(TS_MW, $expires);
+    $token = MWCryptRand::generateHex(32);
+    $hash = md5($token);
+    setRequestEmailToken($request_id, $hash, $expiration);
+    return $token;
+}
+
+function getTokenUrl($request_id, &$expiration) {
+    $token = confirmationToken($request_id, $expiration);
+    // Hack to bypass l10n
+    $title = Title::makeTitle( NS_MAIN, "Special:RequestAccount/ConfirmEmail/$token" );
+    return $title->getCanonicalURL();
+}
+
+function sendConfirmationEmail($request_id) {
+    global $wgLang, $wgUser, $wgSitename, $wgPasswordSender;
+    $request = getAccountRequestById($request_id);
+    if (!$request || empty($request->email) || $request->emailConfirmed) {
+        return false;
+    }
+    $expiration = null;
+    $url = getTokenUrl($request_id, $expiration);
+    $subject = wfMessage('scratch-confirmaccount-email-subject', $request->username)->text();
+    $body = wfMessage(
+        'scratch-confirmaccount-email-body',
+        $request->username,
+        $wgSitename,
+        $url,
+        $wgLang->userTimeAndDate($expiration, $wgUser)
+    )->text();
+    $sender = new MailAddress($wgPasswordSender, wfMessage('emailsender')->text());
+    $to = new MailAddress($request->email, $request->username);
+    UserMailer::send($to, $sender, $subject, $body);
+    return true;
+}

--- a/src/objects/AccountRequest.php
+++ b/src/objects/AccountRequest.php
@@ -2,24 +2,45 @@
 class AccountRequest {
 	var $id;
 	var $username;
+    var $email;
 	var $requestNotes;
 	var $status;
 	var $timestamp;
 	var $lastUpdated;
 	var $expiry;
 	var $passwordHash;
+    var $emailConfirmed;
+    var $emailToken;
+    var $emailExpiry;
 
-	function __construct($id, $username, $passwordHash, $requestNotes, $status, $timestamp, $lastUpdated, $expiry) {
+	function __construct($id, $username, $email, $passwordHash, $requestNotes, $status, $timestamp, $lastUpdated, $expiry, $emailConfirmed, $emailToken, $emailExpiry) {
 		$this->id = $id;
 		$this->username = $username;
+        $this->email = $email;
 		$this->requestNotes = $requestNotes;
 		$this->status = $status;
 		$this->timestamp = $timestamp;
 		$this->passwordHash = $passwordHash;
+        $this->emailConfirmed = $emailConfirmed;
+        $this->emailToken = $emailToken;
+        $this->emailExpiry = $emailExpiry;
 	}
 
 	static function fromRow($row) {
-		return new AccountRequest($row->request_id, $row->request_username, $row->password_hash, $row->request_notes, $row->request_status, $row->request_timestamp, $row->request_last_updated, $row->request_expiry);
+		return new AccountRequest(
+            $row->request_id,
+            $row->request_username,
+            $row->request_email,
+            $row->password_hash,
+            $row->request_notes,
+            $row->request_status,
+            $row->request_timestamp,
+            $row->request_last_updated,
+            $row->request_expiry,
+            $row->request_email_confirmed,
+            $row->request_email_token,
+            $row->request_email_token_expiry,
+        );
 	}
 }
 
@@ -44,12 +65,12 @@ class AccountRequestHistoryEntry {
 class AccountRequestUsernameBlock {
 	var $blockedUsername;
 	var $reason;
-	
+
 	function __construct($blockedUsername, $reason) {
 		$this->blockedUsername = $blockedUsername;
 		$this->reason = $reason;
 	}
-	
+
 	static function fromRow($row) {
 		return new AccountRequestUsernameBlock($row->block_username, $row->block_reason);
 	}


### PR DESCRIPTION
Took hours to develop.

Email support:
- Added setting email, but only if it is confirmed. Unconfirmed users will need to set again (on MW)
- Added email confirmation
- Added re-sending from the request page