### PR TITLE
More optimizations

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -21,13 +21,15 @@
 	},
 	"Hooks": {
 		"LoadExtensionSchemaUpdates": "ScratchConfirmAccountHooks::onLoadExtensionSchemaUpdates",
-		"BeforePageDisplay": "ScratchConfirmAccountHooks::pendingRequestNotice"
+		"BeforePageDisplay": "ScratchConfirmAccountHooks::pendingRequestNotice",
+		"GetPreferences": "ScratchConfirmAccountHooks::onGetPreferences"
 	},
 	"ResourceModules": {
 		"ext.scratchConfirmAccount": {
 			"styles": "main.css",
 			"localBasePath": "resources",
-			"remoteExtPath": "scratch-confirmaccount-v3/resources"
+			"remoteExtPath": "scratch-confirmaccount-v3/resources",
+			"packageFiles": ["main.js"]
 		}
 	},
 	"config": {
@@ -36,5 +38,8 @@
 		"ScratchAccountRequestRejectCooldownDays": 7,
 		"ScratchAccountCheckDisallowNewScratcher": false,
 		"ScratchAccountJoinedRequirement": 0
+	},
+	"DefaultUserOptions": {
+		"scratch-confirmaccount-open-scratch": true
 	}
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -55,6 +55,10 @@
 	"scratch-confirmaccount-search-label": "Search by username",
 	"scratch-confirmaccount-search": "Search",
 	"scratch-confirmaccount-account-created": "Account created.",
+	"scratch-confirmaccount-add-block": "Add new block",
+	"scratch-confirmaccount-not-blocked": "The username is not blocked.",
+	"scratch-confirmaccount-block-invalid-username": "You must enter the username to block.",
+	"scratch-confirmaccount-block-invalid-reason": "You must enter the reason.",
 
 	"scratch-confirmaccount-invalid-username": "The username is invalid. Make sure to type your Scratch username. Due to technical reasons, some usernames which start or end with underscore are not allowed. Please contact an administrator if this is the case for you",
 	"scratch-confirmaccount-user-exists": "The user is already registered.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -106,5 +106,7 @@
 	"scratch-confirmaccount-requests-awaiting-isare": "{{PLURAL:$1|is|are}}",
 
 	"scratch-confirmaccount-email-subject": "Please confirm the email for $1",
-	"scratch-confirmaccount-email-body": "Hello $1,\n\nSomeone requested an account on $2. To confirm the email, please open this address in your browser:\n\n$3\n\nThis link will expire at $4. Note that you will be asked to enter your username and password during the process.\nConfirming your email address is optional, but it will allow you to reset your password via email. If you did not request the account on $2, please ignore this email."
+	"scratch-confirmaccount-email-body": "Hello $1,\n\nSomeone requested an account on $2. To confirm the email, please open this address in your browser:\n\n$3\n\nThis link will expire at $4. Note that you will be asked to enter your username and password during the process.\nConfirming your email address is optional, but it will allow you to reset your password via email. If you did not request the account on $2, please ignore this email.",
+	
+	"scratch-confirmaccount-open-scratch": "Open Scratch profile after handling new requests"
 }

--- a/resources/main.js
+++ b/resources/main.js
@@ -1,0 +1,11 @@
+$(function () {
+    Array.prototype.forEach.call(document.getElementsByClassName('mw-scratch-confirmaccount-request-form'), el => {
+        if (!el.shouldOpenScratchPage) return;
+        if (el.shouldOpenScratchPage.value === '1') {
+            el.addEventListener('submit', ev => {
+                const profileLink = document.getElementById('mw-scratch-confirmaccount-profile-link');
+                if (profileLink) profileLink.click();
+            });
+        }
+    });
+});

--- a/src/ScratchConfirmAccountHooks.php
+++ b/src/ScratchConfirmAccountHooks.php
@@ -51,4 +51,18 @@ class ScratchConfirmAccountHooks {
 
 		return true;
 	}
+	
+	public static function onGetPreferences($user, &$preferences) {
+		//don't show if the user doesn't have permission to create accounts
+		if (!$user->isAllowed('createaccount')) {
+			return true;
+		}
+		
+		$preferences['scratch-confirmaccount-open-scratch'] = [
+			'type' => 'toggle',
+			'label-message' => 'scratch-confirmaccount-open-scratch',
+			'section' => 'rendering/advancedrendering'
+		];
+		return true;
+	}
 }

--- a/src/SpecialConfirmAccounts.php
+++ b/src/SpecialConfirmAccounts.php
@@ -242,9 +242,11 @@ class SpecialConfirmAccounts extends SpecialPage {
 
 		if (!$username) {
 			$this->showErrorPage('error', 'scratch-confirmaccount-block-invalid-username');
+			return;
 		}
 		if (!$reason) {
 			$this->showErrorPage('error', 'scratch-confirmaccount-block-invalid-reason');
+			return;
 		}
 
 		$block = getSingleBlock($username);

--- a/src/SpecialConfirmAccounts.php
+++ b/src/SpecialConfirmAccounts.php
@@ -33,7 +33,7 @@ class AccountRequestPager extends AbstractAccountRequestPager {
 
 class SpecialConfirmAccounts extends SpecialPage {
 	function __construct() {
-		parent::__construct( 'ConfirmAccounts' );
+		parent::__construct( 'ConfirmAccounts', 'createaccount' );
 	}
 
 	function getGroupName() {

--- a/src/SpecialConfirmAccounts.php
+++ b/src/SpecialConfirmAccounts.php
@@ -86,7 +86,7 @@ class SpecialConfirmAccounts extends SpecialPage {
 		}
 
 		//also show a form to add a new block
-		$output->addHTML(Html::element('h3', [], 'Add new block')); //TODO: i18n this
+		$output->addHTML(Html::element('h3', [], wfMessage('scratch-confirmaccount-add-block')->text()));
 		$this->singleBlockForm('', $request, $output);
 	}
 
@@ -96,7 +96,7 @@ class SpecialConfirmAccounts extends SpecialPage {
 		if ($blockedUsername) {
 			$block = getSingleBlock($blockedUsername);
 			if (!$block) {
-				//TODO: show an error
+				$output->showErrorPage('error', 'scratch-confirmaccount-not-blocked');
 				return;
 			}
 		} else {
@@ -237,15 +237,14 @@ class SpecialConfirmAccounts extends SpecialPage {
 	function handleBlockFormSubmission(&$request, &$output) {
 		global $wgUser;
 
-		//TODO: show error message
 		$username = $request->getText('username');
 		$reason = $request->getText('reason');
 
 		if (!$username) {
-			$this->showErrorPage();
+			$this->showErrorPage('error', 'scratch-confirmaccount-block-invalid-username');
 		}
 		if (!$reason) {
-			$this->showErrorPage();
+			$this->showErrorPage('error', 'scratch-confirmaccount-block-invalid-reason');
 		}
 
 		$block = getSingleBlock($username);
@@ -263,7 +262,7 @@ class SpecialConfirmAccounts extends SpecialPage {
 
 		$block = getSingleBlock($username);
 		if (!$block) {
-			//TODO: show an error page for how this user was never blocked
+			$output->showErrorPage('error', 'scratch-confirmaccount-not-blocked');
 			return;
 		}
 


### PR DESCRIPTION
## Bugfixes
- Fixed request validation bypass using different cases
- i18n more strings
- Special:SpecialPages will no longer list ConfirmAccounts for unauthorized users

## Features
- New preference option, available at Rendering/Advanced Options tab, enabled by default: Open Scratch profile when handling new request
- This only triggers when handling New request and not Accepted/Rejected/Awaiting Admin