### PR TITLE
Don't change status by user if it is New request

### DIFF
--- a/src/RequestPage.php
+++ b/src/RequestPage.php
@@ -436,8 +436,10 @@ function handleRequestActionSubmission($userContext, &$request, &$output, &$sess
 		$output->showErrorPage('error', 'scratch-confirmaccount-action-unauthorized');
 		return;
 	}
+	
+	$updateStatus = $userContext == 'admin' || $accountRequest->status != 'new';
 
-	actionRequest($accountRequest, $action, $userContext == 'admin' ? $wgUser->getId() : null, $request->getText('comment'));
+	actionRequest($accountRequest, $updateStatus, $action, $userContext == 'admin' ? $wgUser->getId() : null, $request->getText('comment'));
 	if ($action == 'set-status-accepted') {
 		handleAccountCreation($accountRequest, $output);
 	} else {

--- a/src/database/DatabaseInteractions.php
+++ b/src/database/DatabaseInteractions.php
@@ -145,7 +145,7 @@ function getAccountRequestById($id) {
 	return $result ? AccountRequest::fromRow($result) : false;
 }
 
-function actionRequest(AccountRequest $request, string $action, $userPerformingAction, string $comment) {
+function actionRequest(AccountRequest $request, bool $updateStatus, string $action, $userPerformingAction, string $comment) {
 	global $wgScratchAccountRequestRejectCooldownDays;
 	$dbw = wfGetDB( DB_MASTER );
 
@@ -160,7 +160,10 @@ function actionRequest(AccountRequest $request, string $action, $userPerformingA
 
 	//set the timestamp for when the request was last updated
 	$request_update_fields = ['request_last_updated' => $dbw->timestamp()];
-	if (isset(actionToStatus[$action])) { //if the action also updates the status, then set the status appropriately
+	if (isset(actionToStatus[$action]) && $updateStatus) {
+		// if the action also updates the status and $updateStatus is true
+		// then set the status appropriately
+		// $updateStatus could be false e.g. user commenting to New request
 		$request_update_fields['request_status'] = actionToStatus[$action];
 	}
 	if (in_array($action, expirationActions)) { //and if the action makes the request expire, make the request expire


### PR DESCRIPTION
Users could change the status from New to Awaiting Admin by commenting, which should not happen because it's still unhandled.