### PR TITLE
CheckUser integration

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -60,6 +60,10 @@
 	"scratch-confirmaccount-block-invalid-username": "You must enter the username to block.",
 	"scratch-confirmaccount-block-invalid-reason": "You must enter the reason.",
 	"scratch-confirmaccount-csrf": "The action was prevented to protect the wiki from an [[wikipedia:Cross-site request forgery|CSRF attack]]. Please try again.",
+	"scratch-confirmaccount-ipaddress": "IP address",
+	"scratch-confirmaccount-ip-warning": "Warning",
+	"scratch-confirmaccount-ip-warning-request": "The following accounts have made account requests from the same IP address as this user:",
+	"scratch-confirmaccount-ip-warning-checkuser": "The following accounts have made edits from the same IP address as this user:",
 
 	"scratch-confirmaccount-invalid-username": "The username is invalid. Make sure to type your Scratch username. Due to technical reasons, some usernames which start or end with underscore are not allowed. Please contact an administrator if this is the case for you",
 	"scratch-confirmaccount-user-exists": "The user is already registered.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -106,6 +106,7 @@
 	"scratch-confirmaccount-new-scratcher": "New Scratchers cannot submit account requests.",
 	"scratch-confirmaccount-joinedat": "You must have been registered on Scratch for at least $1 days to request an account.",
 	"scratch-confirmaccount-profile-error": "There was an error while checking your Scratch account. Try again later.",
+	"scratch-confirmaccount-logged-in": "'''Note: You are already logged in with a registered account.'''",
 
 	"scratch-confirmaccount-requests-awaiting": "<b>$2</b> $1 $3 awaiting. <b>Your attention is needed!</b>",
 	"scratch-confirmaccount-requests-awaiting-linktext": "{{PLURAL:$1|request|requests}}",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -58,6 +58,10 @@
 	"scratch-confirmaccount-block-invalid-username": "Error when username to block is missing or invalid",
 	"scratch-confirmaccount-block-invalid-reason": "Error when block reason is missing",
 	"scratch-confirmaccount-csrf": "Error shown when preventing CSRF",
+	"scratch-confirmaccount-ipaddress": "Label for IP address field",
+	"scratch-confirmaccount-ip-warning": "Label for warning",
+	"scratch-confirmaccount-ip-warning-request": "Warning shown when the user has requested an account before",
+	"scratch-confirmaccount-ip-warning-checkuser": "Warning shown when the user has edited before",
 
 	"scratch-confirmaccount-invalid-username": "Error when Scratch username input is invalid",
 	"scratch-confirmaccount-user-exists": "Error when username is already registered",
@@ -100,6 +104,7 @@
 	"scratch-confirmaccount-new-scratcher": "Error when attempting to request as a New Scratcher if it is prohibited",
 	"scratch-confirmaccount-joinedat": "Error when attempting to request from a Scratch account that is too young - parameter is minimum age of account, in '''days'''",
 	"scratch-confirmaccount-profile-error": "Error when fetching profile data fails",
+	"scratch-confirmaccount-logged-in": "Warning shown in the request page when the user is already logged in",
 
 	"scratch-confirmaccount-requests-awaiting": "[[Special:RecentChanges]] banner indicating requests are awaiting",
 	"scratch-confirmaccount-requests-awaiting-linktext": "Parameter 1 of requests-awaiting message",

--- a/resources/main.css
+++ b/resources/main.css
@@ -39,3 +39,8 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
+
+.mw-scratch-confirmaccount-alt-warning {
+	color: red;
+	font-weight: bold;
+}

--- a/sql/requests.sql
+++ b/sql/requests.sql
@@ -22,5 +22,6 @@ CREATE INDEX IF NOT EXISTS /*i*/request_username ON /*_*/scratch_accountrequest_
 CREATE INDEX IF NOT EXISTS /*i*/request_status ON /*_*/scratch_accountrequest_request (request_status);
 CREATE INDEX IF NOT EXISTS /*i*/request_last_updated ON /*_*/scratch_accountrequest_request (request_last_updated);
 CREATE INDEX IF NOT EXISTS /*i*/request_expiry ON /*_*/scratch_accountrequest_request (request_expiry);
+CREATE INDEX IF NOT EXISTS /*i*/request_ip ON /*_*/scratch_accountrequest_request (request_ip);
 
 COMMIT;

--- a/src/RequestPage.php
+++ b/src/RequestPage.php
@@ -356,7 +356,7 @@ function requestCheckUserDisplay(AccountRequest &$accountRequest, string $userCo
 		return;
 	}
 	$requestUsernames = array();
-	getRequestUsernamesFromIP($accountRequest->ip, $requestUsernames);
+	getRequestUsernamesFromIP($accountRequest->ip, $requestUsernames, $accountRequest->username);
 	$checkUserUsernames = array();
 	CheckUserIntegration::getCUUsernamesFromIP($accountRequest->ip, $checkUserUsernames);
 	if (empty($requestUsernames) && empty($checkUserUsernames)) {

--- a/src/RequestPage.php
+++ b/src/RequestPage.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/database/DatabaseInteractions.php';
+require_once __DIR__ . '/database/CheckUserIntegration.php';
 require_once __DIR__ . '/common.php';
 
 function isAuthorizedToViewRequest($requestId, $userContext, &$session) {
@@ -207,7 +208,9 @@ function requestActionsForm(AccountRequest &$accountRequest, string $userContext
 	}
 }
 
-function requestMetadataDisplay(AccountRequest &$accountRequest, Language $language, OutputPage &$output) {
+function requestMetadataDisplay(AccountRequest &$accountRequest, string $userContext, Language $language, OutputPage &$output) {
+	global $wgUser;
+	
 	$disp = '';
 	
 	$disp .= Html::element(
@@ -260,6 +263,20 @@ function requestMetadataDisplay(AccountRequest &$accountRequest, Language $langu
 		)
 	);
 	$disp .= Html::closeElement('tr');
+	if ($userContext == 'admin' && CheckUserIntegration::isLoaded() && $wgUser->isAllowed('checkuser')) {
+		$disp .= Html::openElement('tr');
+		$disp .= Html::element(
+			'th',
+			[],
+			wfMessage('scratch-confirmaccount-ipaddress')->text()
+		);
+		$disp .= Html::element(
+			'td',
+			[],
+			$accountRequest->ip
+		);
+		$disp .= Html::closeElement('tr');
+	}
 	$disp .= Html::closeElement('table');
 	
 	$output->addHTML($disp);
@@ -311,6 +328,47 @@ function requestHistoryDisplay(AccountRequest &$accountRequest, array &$history,
 	}, $history));
 	
 	$output->addHTML($disp);
+}
+
+function requestAltWarningDisplay(OutputPage &$output, string $key, array &$usernames) {
+	$disp = Html::openElement('fieldset');
+	$disp .= Html::element(
+		'legend',
+		['class' => 'mw-scratch-confirmaccount-alt-warning'],
+		wfMessage('scratch-confirmaccount-ip-warning')->text()
+	);
+	$disp .= Html::element(
+		'strong',
+		[],
+		wfMessage($key)->text()
+	);
+	$disp .= Html::openElement('ul');
+	$disp .= implode('', array_map(function($value) {
+		return Html::element('li', [], $value);
+	}, $usernames));
+	$disp .= Html::closeElement('ul');
+	$disp .= Html::closeElement('fieldset');
+	$output->addHTML($disp);
+}
+
+function requestCheckUserDisplay(AccountRequest &$accountRequest, string $userContext, OutputPage &$output) {
+	if ($userContext != 'admin') {
+		return;
+	}
+	$requestUsernames = array();
+	getRequestUsernamesFromIP($accountRequest->ip, $requestUsernames);
+	$checkUserUsernames = array();
+	CheckUserIntegration::getCUUsernamesFromIP($accountRequest->ip, $checkUserUsernames);
+	if (empty($requestUsernames) && empty($checkUserUsernames)) {
+		return;
+	}
+	
+	if (!empty($requestUsernames)) {
+		requestAltWarningDisplay($output, 'scratch-confirmaccount-ip-warning-request', $requestUsernames);
+	}
+	if (!empty($checkUserUsernames)) {
+		requestAltWarningDisplay($output, 'scratch-confirmaccount-ip-warning-checkuser', $checkUserUsernames);
+	}
 }
 
 function emailConfirmationForm(AccountRequest &$accountRequest, string $userContext, OutputPage &$output, SpecialPage &$pageContext, &$session) {
@@ -371,9 +429,10 @@ function requestPage($requestId, string $userContext, OutputPage &$output, Speci
 	
 	$hasBeenHandledByAdminBefore = sizeof(array_filter($history, function($historyEntry) { return isset(actionToStatus[$historyEntry->action]) && in_array('admin', actions[$historyEntry->action]['performers']); })) > 0;
 
-	requestMetadataDisplay($accountRequest, $language, $output);
+	requestMetadataDisplay($accountRequest, $userContext, $language, $output);
 	requestNotesDisplay($accountRequest, $output);
 	requestHistoryDisplay($accountRequest, $history, $language, $output);
+	requestCheckUserDisplay($accountRequest, $userContext, $output);
 	requestActionsForm($accountRequest, $userContext, $hasBeenHandledByAdminBefore, $output, $pageContext, $session);
 	emailConfirmationForm($accountRequest, $userContext, $output, $pageContext,$session);
 }

--- a/src/SpecialRequestAccount.php
+++ b/src/SpecialRequestAccount.php
@@ -316,6 +316,10 @@ class SpecialRequestAccount extends SpecialPage {
 			$form .= Html::element('p', ['class' => 'error'], $error);
 		}
 		
+		if ($this->getUser()->isRegistered()) {
+			$form .= Html::rawElement('p', [], wfMessage('scratch-confirmaccount-logged-in')->parse());
+		}
+		
 		$form .= Html::rawElement('p', [], wfMessage('scratch-confirmaccount-view-request')->parse());
 
 		//form body

--- a/src/database/CheckUserIntegration.php
+++ b/src/database/CheckUserIntegration.php
@@ -1,0 +1,25 @@
+<?php
+
+class CheckUserIntegration {
+    public static function isLoaded () {
+        return ExtensionRegistry::getInstance()->isLoaded('CheckUser');
+    }
+    
+    public static function getCUUsernamesFromIP ($ip, &$usernames) {
+        if (!self::isLoaded()) {
+            $usernames = array();
+            return;
+        }
+        
+        $dbr = wfGetDB(DB_REPLICA);
+        
+        $usernames = $dbr->selectFieldValues(
+            ['cu_changes', 'user'],
+            'DISTINCT user_name',
+            ['cuc_ip_hex' => IP::toHex($ip)],
+            __METHOD__,
+            array(),
+            ['user' => ['LEFT JOIN', 'user_id=cuc_user']]
+        );
+    }
+}

--- a/src/database/DatabaseInteractions.php
+++ b/src/database/DatabaseInteractions.php
@@ -315,3 +315,13 @@ function setRequestEmailConfirmed($request_id) {
 		__METHOD__
 	);
 }
+
+function getRequestUsernamesFromIP($ip, &$usernames) {
+	$dbr = wfGetDB(DB_REPLICA);
+	$usernames = $dbr->selectFieldValues(
+		'scratch_accountrequest_request',
+		'request_username',
+		['request_ip' => $ip],
+		__METHOD__
+	);
+}

--- a/src/database/DatabaseInteractions.php
+++ b/src/database/DatabaseInteractions.php
@@ -316,12 +316,15 @@ function setRequestEmailConfirmed($request_id) {
 	);
 }
 
-function getRequestUsernamesFromIP($ip, &$usernames) {
+function getRequestUsernamesFromIP($ip, &$usernames, $request_username) {
 	$dbr = wfGetDB(DB_REPLICA);
 	$usernames = $dbr->selectFieldValues(
 		'scratch_accountrequest_request',
 		'request_username',
-		['request_ip' => $ip],
+		[
+			'request_ip' => $ip,
+			'LOWER(CONVERT(request_username using utf8)) != ' . $dbr->addQuotes(strtolower($request_username))
+		],
 		__METHOD__
 	);
 }

--- a/src/objects/AccountRequest.php
+++ b/src/objects/AccountRequest.php
@@ -6,6 +6,7 @@ class AccountRequest {
 	var $requestNotes;
 	var $status;
 	var $timestamp;
+	var $ip;
 	var $lastUpdated;
 	var $expiry;
 	var $passwordHash;
@@ -13,13 +14,14 @@ class AccountRequest {
 	var $emailToken;
 	var $emailExpiry;
 
-	function __construct($id, $username, $email, $passwordHash, $requestNotes, $status, $timestamp, $lastUpdated, $expiry, $emailConfirmed, $emailToken, $emailExpiry) {
+	function __construct($id, $username, $email, $passwordHash, $requestNotes, $status, $timestamp, $ip, $lastUpdated, $expiry, $emailConfirmed, $emailToken, $emailExpiry) {
 		$this->id = $id;
 		$this->username = $username;
 		$this->email = $email;
 		$this->requestNotes = $requestNotes;
 		$this->status = $status;
 		$this->timestamp = $timestamp;
+		$this->ip = $ip;
 		$this->passwordHash = $passwordHash;
 		$this->lastUpdated = $lastUpdated;
 		$this->emailConfirmed = $emailConfirmed;
@@ -36,6 +38,7 @@ class AccountRequest {
 			$row->request_notes,
 			$row->request_status,
 			$row->request_timestamp,
+			$row->request_ip,
 			$row->request_last_updated,
 			$row->request_expiry,
 			$row->request_email_confirmed,


### PR DESCRIPTION
Resolves #58

This adds CheckUser integration. Permission model is the same as current one.

## Available without CheckUser
- "You are already logged in" warning
- Listing usernames of previous accounts requests from the IP (this ignores requests with the same username case-insensitive)

## Available with CheckUser extension
- Showing IP: IP address is only shown to those with `checkuser` rights
- Listing CheckUser results

![image](https://user-images.githubusercontent.com/33279053/94361434-33badc80-00ef-11eb-91e0-f8914d165ccf.png)
