### PR TITLE
select unique usernames when checking for duplicate account requests

### DIFF
--- a/src/database/DatabaseInteractions.php
+++ b/src/database/DatabaseInteractions.php
@@ -319,7 +319,7 @@ function getRequestUsernamesFromIP($ip, &$usernames, $request_username) {
 	$dbr = wfGetDB(DB_REPLICA);
 	$usernames = $dbr->selectFieldValues(
 		'scratch_accountrequest_request',
-		'request_username',
+		'DISTINCT request_username',
 		[
 			'request_ip' => $ip,
 			'LOWER(CONVERT(request_username using utf8)) != ' . $dbr->addQuotes(strtolower($request_username))


### PR DESCRIPTION
This prevents the problem of a username showing twice if they have already made two account requests.