### PR TITLE
Call checkReadOnly when displaying special pages

### DIFF
--- a/src/SpecialConfirmAccounts.php
+++ b/src/SpecialConfirmAccounts.php
@@ -380,6 +380,7 @@ class SpecialConfirmAccounts extends SpecialPage {
 		$output->addModules('ext.scratchConfirmAccount');
 		$session = $request->getSession();
 		$this->setHeaders();
+		$this->checkReadOnly();
 
 		$this->showTopLinks();
 

--- a/src/SpecialRequestAccount.php
+++ b/src/SpecialRequestAccount.php
@@ -468,6 +468,7 @@ class SpecialRequestAccount extends SpecialPage {
 		$output->addModules('ext.scratchConfirmAccount');
 		$session = $request->getSession();
 		$this->setHeaders();
+		$this->checkReadOnly();
 
 		if ($request->wasPosted()) {
 			return $this->handleFormSubmission($request, $output, $session);


### PR DESCRIPTION
Fixes a bug where account requests can be made and modified when `$wgReadOnly` is set.