### PR TITLE
Make special pages translatable

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -10,6 +10,9 @@
 			"i18n"
 		]
 	},
+	"ExtensionMessagesFiles": {
+		"ScratchConfirmAccount": "src/ScratchConfirmAccount.i18n.alias.php"
+	},
 	"AutoloadClasses": {
 		"SpecialRequestAccount": "src/SpecialRequestAccount.php",
 		"SpecialConfirmAccounts": "src/SpecialConfirmAccounts.php",

--- a/src/ScratchConfirmAccount.i18n.alias.php
+++ b/src/ScratchConfirmAccount.i18n.alias.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Special page aliases for localisation
+ */
+
+$specialPageAliases = [];
+
+// English
+$specialPageAliases['en'] = [
+  'RequestAccount' => [ 'RequestAccount' ],
+  'ConfirmAccounts' => [ 'ConfirmAccounts' ],
+];


### PR DESCRIPTION
Considering there are Scratch Wikis in non-English languages, it would probably be helpful to be able to add aliases for special pages added by this extension.