### PR TITLE
Allow recovering lost passwords

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -16,6 +16,7 @@
 	"AutoloadClasses": {
 		"SpecialRequestAccount": "src/SpecialRequestAccount.php",
 		"SpecialConfirmAccounts": "src/SpecialConfirmAccounts.php",
+		"SpecialRecoverRequestPassword": "src/SpecialRecoverRequestPassword.php",
 		"ScratchConfirmAccountHooks": "src/ScratchConfirmAccountHooks.php",
 		"AccountRequestCleanupJob": "src/jobs/AccountRequestCleanupJob.php",
 		"ExpiredBlockCleanupJob": "src/jobs/ExpiredBlockCleanupJob.php",
@@ -23,7 +24,8 @@
 	},
 	"SpecialPages": {
 		"RequestAccount": "SpecialRequestAccount",
-		"ConfirmAccounts": "SpecialConfirmAccounts"
+		"ConfirmAccounts": "SpecialConfirmAccounts",
+		"RecoverRequestPassword": "SpecialRecoverRequestPassword"
 	},
 	"JobClasses": {
 		"accountRequestCleanup": "AccountRequestCleanupJob",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -147,5 +147,9 @@
 	"scratch-confirmaccount-requirements-bypasses-url": "bypasses",
 	"scratch-confirmaccount-requirements-bypasses-remove": "Remove",
 	"scratch-confirmaccount-requirements-bypasses-admin-text": "Requirements Bypasses",
-	"scratch-confirmaccount-requirements-bypasses-add": "Add bypass"
+	"scratch-confirmaccount-requirements-bypasses-add": "Add bypass",
+	"scratch-confirmaccount-resetpassword-submit": "Reset Password",
+	"recoverrequestpassword": "Recover account request password",
+	"scratch-confirmaccount-resetpassword-no-matching-requests": "No matching requests were found for the username $1",
+	"scratch-confirmaccount-resetpassword-success": "Your account request password has been reset! You can now [[Special:RequestAccount/FindRequest|view your request]]."
 }

--- a/src/SpecialRecoverRequestPassword.php
+++ b/src/SpecialRecoverRequestPassword.php
@@ -5,7 +5,7 @@ require_once __DIR__ . '/database/DatabaseInteractions.php';
 require_once __DIR__ . '/objects/AccountRequest.php';
 require_once __DIR__ . '/common.php';
 require_once __DIR__ . '/email.php';
-require_once __DIR__ . '/RequestPage.php';
+require_once __DIR__ . '/subpages/RequestPage.php';
 
 use MediaWiki\MediaWikiServices;
 

--- a/src/SpecialRecoverRequestPassword.php
+++ b/src/SpecialRecoverRequestPassword.php
@@ -1,0 +1,152 @@
+<?php
+require_once __DIR__ . '/verification/ScratchVerification.php';
+require_once __DIR__ . '/verification/ScratchUserCheck.php';
+require_once __DIR__ . '/database/DatabaseInteractions.php';
+require_once __DIR__ . '/objects/AccountRequest.php';
+require_once __DIR__ . '/common.php';
+require_once __DIR__ . '/email.php';
+require_once __DIR__ . '/RequestPage.php';
+
+use MediaWiki\MediaWikiServices;
+
+class SpecialRecoverRequestPassword extends SpecialPage {
+	function __construct() {
+		parent::__construct( 'RecoverRequestPassword' );
+	}
+
+	function getGroupName() {
+		return 'login';
+	}
+	
+	function passwordResetForm() {
+		global $wgScratchVerificationProjectID;
+		
+		$request = $this->getRequest();
+		$output = $this->getOutput();
+		$session = $request->getSession();
+		
+		$output->enableOOUI();
+		
+		$form = Html::openElement('form', [ 'method' => 'post', 'name' => 'requestaccount', 'action' => $this->getPageTitle()->getLocalUrl(), 'enctype' => 'multipart/form-data' ]);
+		
+		$form .= new OOUI\FieldsetLayout( [
+			'items' => [
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget( [
+						'name' => 'scratchusername',
+						'required' => true,
+						'value' => $request->getText('scratchusername')
+					] ),
+					[
+						'label' => wfMessage('scratch-confirmaccount-scratchusername')->text(),
+						'align' => 'top',
+					]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget( [
+						'name' => 'password',
+						'type' => 'password',
+						'required' => true
+					] ),
+					[
+						'label' => wfMessage('scratch-confirmaccount-password')->text(),
+						'align' => 'top',
+						'notices' => [wfMessage('scratch-confirmaccount-password-caption')->parse()]
+					]
+				),
+				new OOUI\FieldLayout(
+					new OOUI\TextInputWidget( [
+						'name' => 'password2',
+						'type' => 'password',
+						'required' => true
+					]),
+					[
+						'label' => wfMessage('scratch-confirmaccount-password2')->text(),
+						'align' => 'top',
+					]
+				),
+			]
+		]);
+
+		$form .= Html::rawElement(
+			'p',
+			[],
+			wfMessage('scratch-confirmaccount-vercode-explanation', sprintf(ScratchVerification::PROJECT_LINK, $wgScratchVerificationProjectID))->parse()
+		);
+		$form .= Html::element(
+			'p',
+			[
+				'class' => 'mw-scratch-confirmaccount-verifcode',
+		   		'id' => 'mw-scratch-confirmaccount-verifcode'
+		  	],
+			ScratchVerification::sessionVerificationCode($session)
+		);
+		$form .= new OOUI\ButtonWidget([
+			'id' => 'mw-scratch-confirmaccount-click-copy',
+			'classes' => ['mw-scratch-confirmaccount-click-copy'],
+			'label' => wfMessage('scratch-confirmaccount-click-copy')->text()
+		]);
+		
+		$form .= Html::element('input', [
+			'type' => 'hidden',
+			'name' => 'csrftoken',
+			'value' => setCSRFToken($session)
+		]);
+		
+		$form .= new OOUI\ButtonInputWidget([
+			'type' => 'submit',
+			'flags' => ['primary', 'progressive'],
+			'label' => wfMessage('scratch-confirmaccount-request-submit')->parse()
+		]);
+		
+		$form .= Html::closeElement('form');
+
+		$output->addHTML($form);
+	}
+	
+	function handleFormSubmission() {
+		$request = $this->getRequest();
+		$output = $this->getOutput();
+		$session = $request->getSession();
+
+		if (isCSRF($session, $request->getText('csrftoken'))) {
+			$output->showErrorPage('error', 'scratch-confirmaccount-csrf');
+			return;
+		}
+		
+		$username = $request->getText('username');
+		$password = $request->getText('password');
+		
+		//TODO: find any matching requests
+		
+		//TODO: do scratch verification
+		
+		//TODO: reset the password
+		
+		$dbw = getTransactableDatabase(__METHOD__);
+		
+		commitTransaction($dbw, __METHOD__);
+	}
+
+	function execute( $par ) {
+		$request = $this->getRequest();
+		$output = $this->getOutput();
+		$language = $this->getLanguage();
+		
+		$output->setPageTitle( $this->msg( "requestaccount" )->escaped() );
+		
+		$output->addModules('ext.scratchConfirmAccount.js');
+		$output->addModuleStyles('ext.scratchConfirmAccount.css');
+		
+		$session = $request->getSession();
+		$this->setHeaders();
+		
+		$this->checkReadOnly();
+
+		if ($request->wasPosted()) {
+			return $this->handleFormSubmission();
+		} else {
+			return $this->passwordResetForm();
+		}
+	}
+}

--- a/src/database/DatabaseInteractions.php
+++ b/src/database/DatabaseInteractions.php
@@ -90,6 +90,8 @@ function createAccountRequest(string $username, string $passwordHash, string $re
 }
 
 function resetAccountRequestPassword(AccountRequest $request, string $passwordHash, bool $reactivateOldRequests, IDatabase $dbw) {
+	global $wgScratchAccountRequestRejectCooldownDays;
+	
 	$fields = ['password_hash' => $passwordHash];
 	
 	if ($reactivateOldRequests && $request->isExpired()) {

--- a/src/database/DatabaseInteractions.php
+++ b/src/database/DatabaseInteractions.php
@@ -89,6 +89,10 @@ function createAccountRequest(string $username, string $passwordHash, string $re
 	return $dbw->insertID();
 }
 
+function resetAccountRequestPassword(AccountRequest $request, string $passwordHash, IDatabase $dbw) {
+	$dbw->update('scratch_accountrequest_request', ['password_hash' => $passwordHash], ['request_id' => $request->id], __METHOD__);
+}
+
 abstract class AbstractAccountRequestPager extends ReverseChronologicalPager {
 	private $criteria;
 	function __construct($username, $status) {

--- a/src/verification/ScratchUserCheck.php
+++ b/src/verification/ScratchUserCheck.php
@@ -1,6 +1,8 @@
 <?php
 require_once __DIR__ . '/../common.php';
 
+use Wikimedia\Timestamp\ConvertibleTimestamp;
+
 class ScratchUserCheck {
 	const PROFILE_URL = 'https://scratch.mit.edu/users/%s/';
 	const STATUS_REGEX = '/<span class=\"group\">[\s]*([\w]{3})/';
@@ -50,6 +52,26 @@ class ScratchUserCheck {
 		}
 		if ((intval(wfTimestamp(TS_UNIX)) - intval($joinedAt)) < $joinedAtRequirement) {
 			return 'scratch-confirmaccount-joinedat';
+		}
+	}
+	
+	public static function joinedBefore($username, $wfTimestamp) {
+		$isScratcher = null;
+		$joinedAt = null;
+		$error = '';
+		self::fetchProfile($username, $isScratcher, $joinedAt, $error);
+		if ($error) {
+			return null;
+		}
+		
+		$scratchTimestamp = new ConvertibleTimestamp($joinedAt);
+		$wikiTimestamp = new ConvertibleTimestamp($wfTimestamp);
+		$diff = $scratchTimestamp->diff($wikiTimestamp);
+				
+		if (!$diff->invert) {
+			return true;
+		} else {
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
This provides a way to recover lost passwords on account requests by using the comment verification system. The following details are important to note:
* Expired requests can be reactivated, but if a request is reactivated it resets the cooldown (i.e. users will have to wait _another_ week after resetting the password) - we can resolve this at a later date if we view this as a problem
* This requires that the request be created _after_ the Scratch account (i.e. to avoid namesnipes after a user is renamed)

Closes #147 