### PR TITLE
Add Rate Limit To Request Actions

### DIFF
--- a/src/subpages/RequestPage.php
+++ b/src/subpages/RequestPage.php
@@ -574,9 +574,9 @@ function handleRequestActionSubmission($userContext, SpecialPage $pageContext, $
 
 	$dbw = getTransactableDatabase($mutexId);
 
-	if($user->pingLimiter("requestaccountaction", 1)){
+	if($user->pingLimiter('requestaccountaction')){
 		cancelTransaction($dbw, $mutexId);
-		$output->showErrorPage("actionthrottled", "actionthrottledtext");
+		$output->showErrorPage('actionthrottled', 'actionthrottledtext');
 		return;
 	}
 	//find the request

--- a/src/subpages/RequestPage.php
+++ b/src/subpages/RequestPage.php
@@ -573,7 +573,12 @@ function handleRequestActionSubmission($userContext, SpecialPage $pageContext, $
 	$mutexId = 'scratch-confirmaccount-action-request-' . $requestId;
 
 	$dbw = getTransactableDatabase($mutexId);
-	
+
+	if($user->pingLimiter("requestaccountaction", 1)){
+		cancelTransaction($dbw, $mutexId);
+		$output->showErrorPage("actionthrottled", "actionthrottledtext");
+		return;
+	}
 	//find the request
 	$accountRequest = getAccountRequestById($requestId, $dbw);
 	if (!$accountRequest) {


### PR DESCRIPTION
Implements Rate-limiting To Request Actions.

Required Config For LocalSettings.php:

`$wgRateLimits["requestaccountaction"]["ip"] = [1, 60];`

Closes #144 