### PR TITLE
Specify language in scraper so it doesn't look for the wrong thing

### DIFF
--- a/src/verification/ScratchUserCheck.php
+++ b/src/verification/ScratchUserCheck.php
@@ -9,7 +9,7 @@ class ScratchUserCheck {
 	private static function fetchProfile($username, &$isScratcher, &$joinedAt, &$error) {
 		$url = sprintf(self::PROFILE_URL, $username);
 		$html = @file_get_contents($url, false, stream_context_create([
-			'http' => ['header' => 'Accept-Language: en\r\nCookie: scratchlanguage=en']
+			'http' => ['header' => "Accept-Language: en\r\nCookie: scratchlanguage=en"]
 		]));
 		if ($html === false) {
 			$isScratcher = null; // can't tell Scratcher status

--- a/src/verification/ScratchUserCheck.php
+++ b/src/verification/ScratchUserCheck.php
@@ -8,9 +8,9 @@ class ScratchUserCheck {
 
 	private static function fetchProfile($username, &$isScratcher, &$joinedAt, &$error) {
 		$url = sprintf(self::PROFILE_URL, $username);
-		$html = @file_get_contents($url, false, stream_context_create(
-			"http" => ["header" => "Accept-Language: en\r\nCookie: scratchlanguage=en"]
-		));
+		$html = @file_get_contents($url, false, stream_context_create([
+			'http' => ['header' => 'Accept-Language: en\r\nCookie: scratchlanguage=en']
+		]));
 		if ($html === false) {
 			$isScratcher = null; // can't tell Scratcher status
 			$error = 'scratch-confirmaccount-profile-error';

--- a/src/verification/ScratchUserCheck.php
+++ b/src/verification/ScratchUserCheck.php
@@ -8,7 +8,9 @@ class ScratchUserCheck {
 
 	private static function fetchProfile($username, &$isScratcher, &$joinedAt, &$error) {
 		$url = sprintf(self::PROFILE_URL, $username);
-		$html = @file_get_contents($url);
+		$html = @file_get_contents($url, false, stream_context_create(
+			"http" => ["header" => "Accept-Language: en\r\nCookie: scratchlanguage=en"]
+		));
 		if ($html === false) {
 			$isScratcher = null; // can't tell Scratcher status
 			$error = 'scratch-confirmaccount-profile-error';


### PR DESCRIPTION
This is a copy of #192 which was mistakenly closed by deleting the fork that the code was in.

Original text:

"Depending on a web server's configuration or location, it may get back a response with a language besides English, breaking the scraper. This fixes that.

This does not currently affect en.scratch-wiki.info because it doesn't put an Accept-Language header by default, and Scratch ignores IP addresses, but it will affect other web servers and may affect en.scratch-wiki.info as well should either of the two aforementioned things change."

Closes #191 