### PR TITLE
Expand technical restrictions warning 

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -75,7 +75,8 @@
 			"localBasePath": "resources",
 			"messages": [
 				"scratch-confirmaccount-click-copy-alert",
-				"createacct-normalization"
+				"scratch-confirmaccount-username-disallowed",
+				"scratch-confirmaccount-username-warning"
 			],
 			"dependencies": [
 				"mediawiki.util",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -76,6 +76,8 @@
 	"scratch-confirmaccount-welcome": "Welcome to the wiki!",
 	"scratch-confirmaccount-welcome-summary": "Welcome!",
 
+	"scratch-confirmaccount-username-disallowed": "Due to technical restrictions, usernames that start with an underscore, end with an underscore, or have two consecutive underscores in the middle cannot be used. Please use a different account to request. If you do not have any other accounts, please contact an administrator for help.",
+	"scratch-confirmaccount-username-warning": "Your username will show up as $1. You may change the capitalization of any of the letters, except for the first letter, which must be capitalized and cannot be lowercase.",
 	"scratch-confirmaccount-invalid-username": "The username is invalid. Make sure to type your Scratch username. Due to technical reasons, some usernames which start or end with underscore are not allowed. Please contact an administrator if this is the case for you",
 	"scratch-confirmaccount-user-exists": "The user is already registered.",
 	"scratch-confirmaccount-request-exists": "The request is already received. Please wait for the administrators to handle it.",

--- a/resources/main.js
+++ b/resources/main.js
@@ -67,9 +67,9 @@ $(function () {
 			noticebox[0] = new mw.message("scratch-confirmaccount-username-disallowed").text();
 		}
 		else{
-			if(currentname[0].match("[A-Za-z]")){// Compare first letter to a regex, to check if it starts with a lowercase letter
+			if(currentname[0].match("[A-Za-z]")){// Compare first letter to a regex, to check if it starts with an uppercase or lowercase letter
 				noticebox[0] = new mw.message("scratch-confirmaccount-username-warning", currentname[0].toUpperCase() + currentname.slice(1)).text();
-				// If it'd change, add a notice with the first letter captialized
+				// If they may want alternative capitalization, add a preview of how it will look once it's approved
 			}
 		}
 	}

--- a/resources/main.js
+++ b/resources/main.js
@@ -57,14 +57,21 @@ $(function () {
     const elem = document.getElementsByName("scratchusername")[0];
     if (!elem) return;
 
-    elem.onblur = function() {
+    elem.onkeyup = function() {
 	var currentname = elem.value || "";
         var usernameblock = new OO.ui.infuse(elem.closest('.oo-ui-layout'));
 	// Start with username input field, and go to the entire username container that OOUI will infuse onto
 	var noticebox = [];
-	if(currentname.length > 0 && currentname[0].match("[a-z]")){// Compare first letter to a regex, to check if it starts with a lowercase letter
-		noticebox[0] = new mw.message("createacct-normalization", "", currentname[0].toUpperCase() + currentname.slice(1)).text();
-		// If it'd change, add a notice with the first letter captialized
+	if(currentname.length > 0){
+		if(currentname.match("^_+|_+$|__+")){
+			noticebox[0] = new mw.message("scratch-confirmaccount-username-disallowed").text();
+		}
+		else{
+			if(currentname[0].match("[A-Za-z]")){// Compare first letter to a regex, to check if it starts with a lowercase letter
+				noticebox[0] = new mw.message("scratch-confirmaccount-username-warning", currentname[0].toUpperCase() + currentname.slice(1)).text();
+				// If it'd change, add a notice with the first letter captialized
+			}
+		}
 	}
 	usernameblock.setNotices(noticebox);// Save out any notices (importantly, this will *remove* a notice if it no longer applies)
     }

--- a/src/SpecialRequestAccount.php
+++ b/src/SpecialRequestAccount.php
@@ -78,7 +78,7 @@ class SpecialRequestAccount extends SpecialPage {
 		}
 
 		//make sure the user actually commented the verification code
-		if (ScratchVerification::topVerifCommenter(ScratchVerification::sessionVerificationCode($session)) !== $username) {
+		if (strtolower(ScratchVerification::topVerifCommenter(ScratchVerification::sessionVerificationCode($session))) !== strtolower($username)) {
 			$out_error = wfMessage('scratch-confirmaccount-verif-missing', $username)->parse();
 			return;
 		}

--- a/src/verification/ScratchUserCheck.php
+++ b/src/verification/ScratchUserCheck.php
@@ -8,7 +8,9 @@ class ScratchUserCheck {
 
 	private static function fetchProfile($username, &$isScratcher, &$joinedAt, &$error) {
 		$url = sprintf(self::PROFILE_URL, $username);
-		$html = @file_get_contents($url);
+		$html = @file_get_contents($url, false, stream_context_create([
+			'http' => ['header' => "Accept-Language: en\r\nCookie: scratchlanguage=en"]
+		]));
 		if ($html === false) {
 			$isScratcher = null; // can't tell Scratcher status
 			$error = 'scratch-confirmaccount-profile-error';


### PR DESCRIPTION
Pull request #194 added the use of a built-in message when a username starts with a lowercase letter. This functionality has been expanded. Now, there are custom messages, and they will show more often. There is a message for when a username uses impossible underscores, and a message for when a username begins with any letter, uppercase or lowercase. Instead of updating once, it updates as you type, so you can preview how it will look on-wiki. This is important to let people know that they can change the appearance of any letter, except the first one. This lets you see how it will look onwiki.

Closes #200

![image](https://github.com/user-attachments/assets/24d9924c-e3db-4e08-86cc-213adacd1055)

![image](https://github.com/user-attachments/assets/580a02c5-ed61-4f54-a46e-8ecc72dc76ce)


![image](https://github.com/user-attachments/assets/a57bf044-23ae-426a-b41f-3ff26e8d1022)
