### PR TITLE
Update to MediaWiki 1.43

### DIFF
--- a/src/SpecialConfirmAccounts.php
+++ b/src/SpecialConfirmAccounts.php
@@ -110,7 +110,7 @@ class SpecialConfirmAccounts extends SpecialPage {
 	}
 
 	//show a form that allows editing an existing block or adding a new one (leave the username blank)
-	function singleBlockForm($blockedUsername, &$request, &$output, &$session, IDatabase $dbr) {
+	function singleBlockForm($blockedUsername, &$request, &$output, &$session, Wikimedia\Rdbms\DBConnRef $dbr) {
 		if (!$this->canViewBlocks()) {
 			throw new PermissionsError('block');
 		}

--- a/src/SpecialRequestAccount.php
+++ b/src/SpecialRequestAccount.php
@@ -26,15 +26,15 @@ class SpecialRequestAccount extends SpecialPage {
 		$this->jobQueueGroup = $jobQueueGroup;
 	}
 
-	function accountRequestFormData(&$out_error, IDatabase $dbr) {
+	function accountRequestFormData(&$out_error, Wikimedia\Rdbms\DBConnRef $dbr) {
 		global $wgScratchAccountJoinedRequirement;
 
 		$request = $this->getRequest();
 		$session = $request->getSession();
 		
 		//if the user is IP banned, don't even consider anything else
-		if ($this->getUser()->isBlockedFromCreateAccount()) {
-			$block = $this->getUser()->getBlock();
+		$block = $this->getUser()->getBlock();
+		if ($block && $block->isCreateAccountBlocked()) {
 			$out_error = wfMessage('scratch-confirmaccount-ip-blocked', $block->getReasonComment()->text)->parse();
 			return;
 		}

--- a/src/database/CheckUserIntegration.php
+++ b/src/database/CheckUserIntegration.php
@@ -17,7 +17,7 @@ class CheckUserIntegration {
 	 * @param dbr A readable database connection
 	 * @return CheckUserEntry[] An array of checkuser records from \p ip, or empty if checkuser is not installed
 	 */
-	public static function getCUUsernamesFromIP($ip, IDatabase $dbr) : array {
+	public static function getCUUsernamesFromIP($ip, Wikimedia\Rdbms\DBConnRef $dbr) : array {
 		if (!self::isLoaded()) {
 			return [];
 		}

--- a/src/subpages/RequestPage.php
+++ b/src/subpages/RequestPage.php
@@ -426,7 +426,7 @@ function requestAltWarningDisplay(OutputPage &$output, string $key, array &$user
  * @param output The page where the output will be displayed
  * @param dbr A readable database connection reference
  */
-function requestCheckUserDisplay(AccountRequest &$accountRequest, string $userContext, OutputPage &$output, IDatabase $dbr) : void {
+function requestCheckUserDisplay(AccountRequest &$accountRequest, string $userContext, OutputPage &$output, Wikimedia\Rdbms\DBConnRef $dbr) : void {
 	if ($userContext !== 'admin') {
 		return;
 	}
@@ -519,7 +519,7 @@ function requestPage($requestId, string $userContext, SpecialPage &$pageContext,
 	emailConfirmationForm($accountRequest, $userContext, $output, $pageContext,$session);
 }
 
-function handleAccountCreation($accountRequest, OutputPage &$output, IDatabase $dbw) {
+function handleAccountCreation($accountRequest, OutputPage &$output, Wikimedia\Rdbms\DBConnRef $dbw) {
 	global $wgAutoWelcomeNewUsers;
 
 	$user = $output->getUser();


### PR DESCRIPTION
MediaWiki introduces DBConnRef, and deprecates isBlockedFromCreateAccount. These changes make the software work on 1.43.

There was also some previous discussion about removing the e-mail feature, but I haven't done that in this PR. It might be worth doing it in a future one.